### PR TITLE
support --reservation option of sbtach at pilot compute description

### DIFF
--- a/pilot/job/slurm.py
+++ b/pilot/job/slurm.py
@@ -73,6 +73,9 @@ class Job(object):
         
         if 'project' in job_description: 
             self.pilot_compute_description['project'] = job_description['project']
+
+        if 'reservation' in job_description:
+            self.pilot_compute_description['reservation'] = job_description['reservation']
         
         self.pilot_compute_description['working_directory'] = os.getcwd()
         if 'working_directory' in job_description: 
@@ -131,6 +134,9 @@ class Job(object):
                 tmp.write("#SBATCH -t %s\n"%str(self.pilot_compute_description["walltime_slurm"]))
                 tmp.write("\n")
                 tmp.write("#SBATCH -A %s\n"%str(self.pilot_compute_description["project"]))
+                tmp.write("\n")
+                if self.pilot_compute_description["reservation"] is not None:
+                    tmp.write("#SBATCH --reservation  %s\n"%str(self.pilot_compute_description["reservation"]))
                 tmp.write("\n")
                 tmp.write("#SBATCH -o %s\n"%self.pilot_compute_description["output"])
                 tmp.write("#SBATCH -e %s\n"%self.pilot_compute_description["error"])

--- a/pilot/plugins/dask/cluster.py
+++ b/pilot/plugins/dask/cluster.py
@@ -34,6 +34,7 @@ class Manager():
                    queue=None,
                    walltime=None,
                    project=None,
+                   reservation=None,
                    config_name="default",
                    extend_job_id=None,
                    pilotcompute_description=None
@@ -58,6 +59,7 @@ class Manager():
                 "number_of_nodes": number_of_nodes,
                 "cores_per_node": cores_per_node,
                 "project": project,
+                "reservation": reservation,
                 "queue": queue,
                 "walltime": walltime,
             }

--- a/pilot/plugins/kafka/cluster.py
+++ b/pilot/plugins/kafka/cluster.py
@@ -32,6 +32,7 @@ class Manager():
                    queue=None,
                    walltime=None,
                    project=None,
+                   reservation = None,
                    config_name="default",
                    extend_job_id=None,
                    pilotcompute_description=None
@@ -56,6 +57,7 @@ class Manager():
                 "number_of_nodes": number_of_nodes,
                 "cores_per_node": cores_per_node,
                 "project": project,
+                "reservation" : reservation,
                 "queue": queue,
                 "walltime": walltime,
             }

--- a/pilot/plugins/spark/cluster.py
+++ b/pilot/plugins/spark/cluster.py
@@ -36,6 +36,7 @@ class Manager():
                    walltime=None,
                    project=None,
                    config_name="default",
+                   reservation = None,
                    extend_job_id=None,
                    pilotcompute_description=None
     ):
@@ -58,6 +59,7 @@ class Manager():
                 "number_of_nodes": number_of_nodes,
                 "cores_per_node": cores_per_node,
                 "project": project,
+                "reservation": reservation,
                 "queue": queue,
                 "walltime": walltime,
             }

--- a/pilot/streaming.py
+++ b/pilot/streaming.py
@@ -214,6 +214,10 @@ class PilotComputeService(object):
         if "project" in pilotcompute_description:
             project = pilotcompute_description["project"]
 
+        reservation = None
+        if 'reservation' in pilotcompute_description:
+            reservation = pilotcompute_description["reservation"]
+
         queue = None
         if "queue" in pilotcompute_description:
             queue = pilotcompute_description["queue"]
@@ -273,6 +277,7 @@ class PilotComputeService(object):
             queue=queue,
             walltime=walltime,
             project=project,
+            reservation=reservation,
             extend_job_id=parent, 
             pilotcompute_description=pilotcompute_description
         )


### PR DESCRIPTION
Example:
```
spark_pilot_description = {
    "resource":"slurm+ssh://login1.wrangler.tacc.utexas.edu",
    "working_directory": os.path.join('/work/03662/tg829618/wrangler', "work"),
    "number_cores": 48,
    "project": "TG-MCB090174",
    "reservation": "dssd+TG-MCB090174+2555",
    "queue": "normal",
    "walltime": 159,
    "type":"spark"
}
```